### PR TITLE
fix: improve Kafka validation and data handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.4
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/kafka_connector.py
+++ b/kafka_connector.py
@@ -77,7 +77,7 @@ class KafkaConnector(phantom.BaseConnector):
             if "key_file" in config:
                 self._client_args.update({"ssl_keyfile": config["key_file"]})
             if "ca_cert" in config:
-                self._client_args.update({"ssl_cafile": config["ca_cert"], "ssl_check_hostname": False})
+                self._client_args.update({"ssl_cafile": config["ca_cert"], "ssl_check_hostname": True})
 
         self._client_args.update({"security_protocol": sec_prot})
 

--- a/kafka_connector.py
+++ b/kafka_connector.py
@@ -309,11 +309,9 @@ class KafkaConnector(phantom.BaseConnector):
         if len(data) == 0:
             return action_result.set_status(phantom.APP_ERROR, consts.KAFKA_ERROR_EMPTY_LIST)
 
-        count = 0
         failed = 0
+        pending_sends = []
         for message in data:
-            count += 1
-
             try:
                 if data_type == "string":
                     message = bytes(message, encoding="utf8")
@@ -330,8 +328,8 @@ class KafkaConnector(phantom.BaseConnector):
 
                     action_result.add_data(self._build_result_dict(send_data))
 
-                elif count == len(data):
-                    send.get()
+                else:
+                    pending_sends.append((message, send))
 
             except KafkaTimeoutError:
                 self.save_progress(consts.KAFKA_ERROR_TIMEOUT)
@@ -342,6 +340,21 @@ class KafkaConnector(phantom.BaseConnector):
                 self.save_progress(consts.KAFKA_PRODUCER_SEND_ERROR.format(e))
                 action_result.add_data({"message": message, "topic": topic, "status": "failed", "error": str(e)})
                 failed += 1
+
+        if not timeout:
+            self._producer.flush()
+
+            for message, send in pending_sends:
+                try:
+                    send.get()
+                except KafkaTimeoutError:
+                    self.save_progress(consts.KAFKA_ERROR_TIMEOUT)
+                    action_result.add_data({"message": message, "topic": topic, "status": "failed", "error": consts.KAFKA_ERROR_TIMEOUT})
+                    failed += 1
+                except Exception as e:
+                    self.save_progress(consts.KAFKA_PRODUCER_SEND_ERROR.format(e))
+                    action_result.add_data({"message": message, "topic": topic, "status": "failed", "error": str(e)})
+                    failed += 1
 
         if failed:
             return action_result.set_status(phantom.APP_ERROR, consts.KAFKA_ERROR_SEND_FAILED.format(failed, "" if failed == 1 else "s"))

--- a/kafka_connector.py
+++ b/kafka_connector.py
@@ -159,10 +159,18 @@ class KafkaConnector(phantom.BaseConnector):
             artifact["container_id"] = container_id
 
         if hasattr(self, "save_artifacts"):
-            self.save_artifacts(artifacts)
+            ret_val, message, _ = self.save_artifacts(artifacts)
+
+            if phantom.is_fail(ret_val):
+                return ret_val, message
         else:
             for artifact in artifacts:
-                self.save_artifact(artifact)
+                ret_val, message, _ = self.save_artifact(artifact)
+
+                if phantom.is_fail(ret_val):
+                    return ret_val, message
+
+        return phantom.APP_SUCCESS, ""
 
     def _seek(self, consumer, tp_list):
         config = self.get_config()
@@ -221,10 +229,6 @@ class KafkaConnector(phantom.BaseConnector):
         for tp in tp_list:
             messages += poll_dict.get(tp, [])
 
-        if not self.is_poll_now():
-            for tp in tp_list:
-                self._state[topic][str(tp.partition)] = consumer.position(tp)
-
         if not messages:
             return action_result.set_status(phantom.APP_SUCCESS, consts.KAFKA_NO_MESSAGES)
 
@@ -254,7 +258,13 @@ class KafkaConnector(phantom.BaseConnector):
             containers = parse_messages(topic, parser_args)
 
         for container in containers:
-            self._save_container(container)
+            ret_val, message = self._save_container(container)
+            if phantom.is_fail(ret_val):
+                return action_result.set_status(phantom.APP_ERROR, consts.KAFKA_ERROR_SAVE_CONTAINER.format(message))
+
+        if not self.is_poll_now():
+            for tp in tp_list:
+                self._state[topic][str(tp.partition)] = consumer.position(tp)
 
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/kafka_consts.py
+++ b/kafka_consts.py
@@ -47,6 +47,7 @@ KAFKA_ERROR_INVALID_PORT = "Could not connect to Kafka on {0} due to:\nInvalid p
 KAFKA_ERROR_EMPTY_LIST = "Got an empty list as message to send. To send an empty list, try '[[]]'"
 KAFKA_ERROR_PARSER_ARGS = "{0}: parse_messages() should take exactly 2 arguments, takes {1} instead"
 KAFKA_ERROR_SSL_CONFIG = "To use SSL, at least one of cert_file, key_file, or ca_cert asset configuration parameters must be filled out"
+KAFKA_ERROR_SAVE_CONTAINER = "Failed to save ingested Kafka data: {0}"
 
 KAFKA_TEST_CONNECTIVITY_FAILED = "Test Connectivity Failed"
 KAFKA_TEST_CONNECTIVITY_PASSED = "Test Connectivity Passed"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 Require TLS hostname verification when Kafka assets use a custom CA certificate (PSAAS-31301).
 Persist Kafka poll offsets only after decoded messages and their containers and artifacts are saved successfully (PSAAS-32240).
+Resolve every Kafka producer send future so broker rejections for intermediate batch messages fail the action (PSAAS-32365).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+Require TLS hostname verification when Kafka assets use a custom CA certificate (PSAAS-31301).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
-Require TLS hostname verification when Kafka assets use a custom CA certificate (PSAAS-31301).
-Persist Kafka poll offsets only after decoded messages and their containers and artifacts are saved successfully (PSAAS-32240).
-Resolve every Kafka producer send future so broker rejections for intermediate batch messages fail the action (PSAAS-32365).
+* Require TLS hostname verification when Kafka assets use a custom CA certificate (PSAAS-31301).
+* Persist Kafka poll offsets only after decoded messages and their containers and artifacts are saved successfully (PSAAS-32240).
+* Resolve every Kafka producer send future so broker rejections for intermediate batch messages fail the action (PSAAS-32365).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 Require TLS hostname verification when Kafka assets use a custom CA certificate (PSAAS-31301).
+Persist Kafka poll offsets only after decoded messages and their containers and artifacts are saved successfully (PSAAS-32240).


### PR DESCRIPTION
## Summary

- require broker hostname verification when Kafka assets use a custom CA
- persist scheduled-poll offsets only after decoding, parsing, and SOAR persistence succeed
- resolve every asynchronous producer future so intermediate broker rejections fail the action
- update connector tooling to dev-cicd-tools v2.2.4

## Tracking

- [PAPP-38222](https://splunk.atlassian.net/browse/PAPP-38222)
- [PSAAS-31301](https://splunk.atlassian.net/browse/PSAAS-31301) (VULN-94026 / FS-2171)
- [PSAAS-32240](https://splunk.atlassian.net/browse/PSAAS-32240) (VULN-94963 / FS-3486)
- [PSAAS-32365](https://splunk.atlassian.net/browse/PSAAS-32365) (VULN-95088 / FS-3611)

## Validation

- `pre-commit run --all-files`

The Jira patch guidance was treated as a recommendation. The polling change uses Kafka at-least-once checkpoint ordering: the connector records the broker position only after the complete fetched batch has been decoded, parsed, and persisted, accepting safe retries instead of silent loss. This pull request was written by Codex with AI assistance.

Merge strategy: merge commit only; do not squash.

Written by Codex.

Quality-gate blocker: https://github.com/phantomcyber/dev-cicd-tools/pull/250 fixes the shared NOTICE hook so it reuses the compatible native wheels already packaged by this connector. A fresh hosted retry reproduced the blocker while compile passed. Written by Codex.